### PR TITLE
Updating create attestation command with flags for latest gcloud CLI

### DIFF
--- a/scripts/create_attestation.sh
+++ b/scripts/create_attestation.sh
@@ -115,7 +115,7 @@ gcloud beta container binauthz attestations create \
     --artifact-url="${IMAGE_PATH}" \
     --attestor="projects/${PROJECT_ID}/attestors/${NAME}" \
     --signature-file=generated_signature.pgp \
-    --pgp-key-fingerprint="$(cat ${NAME}.fpr)"
+    --public-key-id="$(cat ${NAME}.fpr)"
 
 # Clean up the keys and generated artifacts
 rm generated_signature.pgp generated_payload.json ${NAME}.fpr ${NAME}.pass ${NAME}.pass.enc ${NAME}.gpg ${NAME}.gpg.enc


### PR DESCRIPTION
The latest version of gcloud SDK introduced breaking changes to the gcloud beta container binauthz command group causing the create_attestation.sh script to fail.