### PR TITLE
Use Cloud KMS directly instead of gnupg and Cloud Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,34 @@ Options:
 
 ## Create Attestation Script - scripts/create_attestation.sh
 
-Pulls down an encrypted PGP private key from Google Cloud Storage then decrypts it and 
-uses it to create an attestation for the image that was passed in.
+Creates an attestation for the given artifact using Cloud KMS.
 
 ```
-Options:
-  -n <attestor name>   Name to use for attestor
-  -p <project ID>      Project ID
-  -i <image path>      Full image path including sha (gcr.io/my-project/image-name@sha256:....)
-  -b <bucket name>     Name of the GCS Bucket with KMS decryption keys
-  -r <keyring name>    Name of the KMS keyring decryption key
-  -k <key name>        Name of the KMS decryption key
+Global options:
+  -p <project>
+      ID of the Google Cloud project (e.g. "my-project")
+  -i <image>
+      Full image including SHA (e.g. "gcr.io/my-project/my-image@sha245:...")
+
+Attestor options:
+  -a <attestor>
+      ID of the attestor (e.g. "my-attestor")
+  -A <attestor project>
+      ID of the project where the attestor exists. Defaults to the global
+      project ID.
+
+KMS options:
+  -v <kms key version>
+      Version of the KMS key to use for signing (e.g. "1")
+  -k <kms key>
+      Name of the KMS get (e.g. "my-key")
+  -l <kms location>
+      Location of the KMS key (e.g. "global")
+  -r <kms key ring>
+      Name of the KMS keyring (e.g. "my-keyring")
+  -V <kms project>
+      ID of the project where the KMS key exists. Defaults to the global
+      project ID.
 ```
 
 ## Contributing

--- a/cve-checker/go.mod
+++ b/cve-checker/go.mod
@@ -1,0 +1,17 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module github.com/GoogleCloudPlatform/gke-binary-auth-tools/cve-checker
+
+go 1.13

--- a/examples/hello-app/Dockerfile
+++ b/examples/hello-app/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.12 as build
+FROM golang:1.13 as build
 
 WORKDIR /go/src/app
 COPY . .

--- a/examples/hello-app/cloudbuild.yaml
+++ b/examples/hello-app/cloudbuild.yaml
@@ -15,7 +15,7 @@
 steps:
 
 - name: 'gcr.io/cloud-builders/docker'
-  id: Build
+  id: 'Build application and container'
   args:
   - 'build'
   - '-t'
@@ -23,13 +23,13 @@ steps:
   - '.'
 
 - name: 'gcr.io/cloud-builders/docker'
-  id: Push Image to GCR
+  id: 'Push image to Container Registry'
   args:
   - 'push'
   - 'gcr.io/$PROJECT_ID/hello-app:$SHORT_SHA'
 
 - name: gcr.io/$PROJECT_ID/cloudbuild-attestor
-  id: Check Vulnerability Scan Results
+  id: 'Check Vulnerability Scan results'
   entrypoint: 'sh'
   args:
   - -xe
@@ -38,7 +38,7 @@ steps:
      /scripts/check_vulnerabilities.sh -p $PROJECT_ID -i gcr.io/$PROJECT_ID/hello-app:$SHORT_SHA -t 5
 
 - name: 'gcr.io/$PROJECT_ID/cloudbuild-attestor'
-  id: 'Attest'
+  id: 'Attest Vulnerability Scan'
   entrypoint: 'sh'
   args:
   - -xe
@@ -48,7 +48,7 @@ steps:
      /scripts/create_attestation.sh -n $_VULNZ_NOTE_ID -p $PROJECT_ID -i $$FULLY_QUALIFIED_IMAGE -b $PROJECT_ID-keys -r $_KMS_KEYRING  -k $_KMS_KEY
 
 - name: 'gcr.io/cloud-builders/gcloud'
-  id: Generate k8s manifest
+  id: 'Generate Kubernetes manifest'
   entrypoint: /bin/sh
   args:
   - '-c'
@@ -58,18 +58,15 @@ steps:
      sed "s/DIGEST/$${DIGEST}/g" > kubernetes/deployment.yaml
 
 - name: 'gcr.io/cloud-builders/kubectl'
-  id: Deploy to Staging
-  args:
-  - 'apply'
-  - '-f'
-  - 'kubernetes'
+  id: 'Deploy to staging'
+  args: ['apply', '-f', 'kubernetes/']
   env:
-  - 'CLOUDSDK_COMPUTE_ZONE=$_COMPUTE_ZONE'
+  - 'CLOUDSDK_COMPUTE_REGION=$_COMPUTE_REGION'
   - 'CLOUDSDK_CONTAINER_CLUSTER=$_STAGING_CLUSTER'
 
-# This effectively pauses the build for up to 500s until the QA attestion has been applied.
+# Clear the context - this is required until new gcloud and kubectl builders are
+# published which fix the caching bug.
 - name: 'gcr.io/cloud-builders/gcloud'
-  id: Wait for QA Attestation
   entrypoint: /bin/sh
   timeout: 500s
   args:
@@ -80,10 +77,14 @@ steps:
      until gcloud beta container binauthz attestations list --attestor=$_QA_NOTE_ID --artifact-url=$${FULLY_QUALIFIED_IMAGE} | grep $_QA_NOTE_ID; do
        sleep 30
      done
+  id: 'Clear staging context'
+  entrypoint: '/bin/bash'
+  args: ['-c', 'rm -rf ~/.config/gcloud ~/.kube']
 
-# Change to the prod-cluster context this is needed because the build previously used the staging-cluster context.
+# This effectively pauses the build for up to 500s until the QA attestion is
+# applied.
 - name: 'gcr.io/cloud-builders/gcloud'
-  id: Change to Prod Context
+  id: 'Await QA attestation'
   entrypoint: /bin/sh
   timeout: 500s
   args:
@@ -92,11 +93,15 @@ steps:
       gcloud container clusters get-credentials --project="$PROJECT_ID" --zone="$_COMPUTE_ZONE" "$_PROD_CLUSTER"
 
 - name: 'gcr.io/cloud-builders/kubectl'
-  id: Deploy to Production
-  args:
-  - 'apply'
-  - '-f'
-  - 'kubernetes'
+  id: 'Deploy to production'
+  args: ['apply', '-f', 'kubernetes/']
   env:
-  - 'CLOUDSDK_COMPUTE_ZONE=$_COMPUTE_ZONE'
+  - 'CLOUDSDK_COMPUTE_REGION=$_COMPUTE_REGION'
   - 'CLOUDSDK_CONTAINER_CLUSTER=$_PROD_CLUSTER'
+
+# Clear the context - this is required until new gcloud and kubectl builders are
+# published which fix the caching bug.
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: 'Clear production context'
+  entrypoint: '/bin/bash'
+  args: ['-c', 'rm -rf ~/.config/gcloud ~/.kube']

--- a/examples/hello-app/cloudbuild.yaml
+++ b/examples/hello-app/cloudbuild.yaml
@@ -43,9 +43,16 @@ steps:
   args:
   - -xe
   - -c
-  - |
-     FULLY_QUALIFIED_IMAGE=$(gcloud container images describe --format 'value(image_summary.fully_qualified_digest)' gcr.io/$PROJECT_ID/hello-app:$SHORT_SHA)
-     /scripts/create_attestation.sh -n $_VULNZ_NOTE_ID -p $PROJECT_ID -i $$FULLY_QUALIFIED_IMAGE -b $PROJECT_ID-keys -r $_KMS_KEYRING  -k $_KMS_KEY
+  - |-
+      FQ_DIGEST=$(gcloud container images describe --format 'value(image_summary.fully_qualified_digest)' gcr.io/$PROJECT_ID/hello-app:$SHORT_SHA)
+      /scripts/create_attestation.sh \
+        -p "$PROJECT_ID" \
+        -i "$${FQ_DIGEST}" \
+        -a "$_VULNZ_ATTESTOR" \
+        -v "$_VULNZ_KMS_KEY_VERSION" \
+        -k "$_VULNZ_KMS_KEY" \
+        -l "$_KMS_LOCATION" \
+        -r "$_KMS_KEYRING"
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: 'Generate Kubernetes manifest'

--- a/examples/hello-app/cloudbuild.yaml
+++ b/examples/hello-app/cloudbuild.yaml
@@ -59,10 +59,10 @@ steps:
   entrypoint: /bin/sh
   args:
   - '-c'
-  - |
-     DIGEST=$(gcloud container images describe --format 'value(image_summary.digest)' gcr.io/$PROJECT_ID/hello-app:$SHORT_SHA)
-     sed "s/GOOGLE_CLOUD_PROJECT/${PROJECT_ID}/g" kubernetes/deployment.yaml.tpl | \
-     sed "s/DIGEST/$${DIGEST}/g" > kubernetes/deployment.yaml
+  - |-
+      DIGEST=$(gcloud container images describe --format 'value(image_summary.digest)' gcr.io/$PROJECT_ID/hello-app:$SHORT_SHA)
+      sed "s/GOOGLE_CLOUD_PROJECT/${PROJECT_ID}/g" kubernetes/deployment.yaml.tpl | \
+      sed "s/DIGEST/$${DIGEST}/g" > kubernetes/deployment.yaml
 
 - name: 'gcr.io/cloud-builders/kubectl'
   id: 'Deploy to staging'
@@ -74,16 +74,6 @@ steps:
 # Clear the context - this is required until new gcloud and kubectl builders are
 # published which fix the caching bug.
 - name: 'gcr.io/cloud-builders/gcloud'
-  entrypoint: /bin/sh
-  timeout: 500s
-  args:
-  - '-c'
-  - |
-     FULLY_QUALIFIED_IMAGE=$(gcloud container images describe --format 'value(image_summary.fully_qualified_digest)' gcr.io/$PROJECT_ID/hello-app:$SHORT_SHA)
-     
-     until gcloud beta container binauthz attestations list --attestor=$_QA_NOTE_ID --artifact-url=$${FULLY_QUALIFIED_IMAGE} | grep $_QA_NOTE_ID; do
-       sleep 30
-     done
   id: 'Clear staging context'
   entrypoint: '/bin/bash'
   args: ['-c', 'rm -rf ~/.config/gcloud ~/.kube']
@@ -95,9 +85,38 @@ steps:
   entrypoint: /bin/sh
   timeout: 500s
   args:
+  - '-e'
   - '-c'
-  - |
-      gcloud container clusters get-credentials --project="$PROJECT_ID" --zone="$_COMPUTE_ZONE" "$_PROD_CLUSTER"
+  - |-
+      FULLY_QUALIFIED_IMAGE=$(gcloud container images describe --format 'value(image_summary.fully_qualified_digest)' gcr.io/$PROJECT_ID/hello-app:$SHORT_SHA)
+
+      cat <<EOF
+      Waiting for QA attestation... Attest the image with the following command:
+
+      gcloud beta container binauthz attestations sign-and-create \
+        --project "$PROJECT_ID" \
+        --artifact-url "$${FULLY_QUALIFIED_IMAGE}" \
+        --attestor "$_QA_ATTESTOR" \
+        --attestor-project "$PROJECT_ID" \
+        --keyversion "$_QA_KMS_KEY_VERSION" \
+        --keyversion-key "$_QA_KMS_KEY" \
+        --keyversion-location "$_KMS_LOCATION" \
+        --keyversion-keyring "$_KMS_KEYRING" \
+        --keyversion-project "$PROJECT_ID"
+
+      EOF
+
+      until gcloud beta container binauthz attestations list \
+        --project "$PROJECT_ID" \
+        --attestor "$_QA_ATTESTOR" \
+        --attestor-project "$PROJECT_ID" \
+        --artifact-url "$${FULLY_QUALIFIED_IMAGE}" \
+        2>&1 \
+        | grep -q "$_QA_KMS_KEY"
+      do
+        echo "Awaiting attestation..."
+        sleep 10
+      done
 
 - name: 'gcr.io/cloud-builders/kubectl'
   id: 'Deploy to production'

--- a/scripts/check_vulnerabilities.sh
+++ b/scripts/check_vulnerabilities.sh
@@ -14,13 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+SCRIPT_NAME="${0##*/}"
+
 die() {
-  echo "${0##*/}: error: $*" >&2
+  echo "${SCRIPT_NAME}: $*" >&2
   exit 1
 }
 
 usage() {
-  echo "Usage: check_vulnerabilities.sh [options] [args]
+  echo "Usage: ${SCRIPT_NAME} [options] [args]
 
 Check if an image has CRITICAL vulnerabilities.
 
@@ -105,4 +107,3 @@ else
     echo "Scan returned CRITICAL Vulnerabilities for ${IMAGE_PATH}"
     exit 1
 fi
-

--- a/scripts/create_attestation.sh
+++ b/scripts/create_attestation.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -xe
+#!/bin/bash
+set -eEuo pipefail
 
 # Copyright 2019 Google LLC
 #
@@ -14,108 +15,119 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+SCRIPT_NAME="${0##*/}"
+
 die() {
-  echo "${0##*/}: error: $*" >&2
+  echo "${SCRIPT_NAME}: $*" >&2
   exit 1
 }
 
 usage() {
-  echo "Usage: create_attestor.sh [options] [args]
+  echo -n "Usage: ${SCRIPT_NAME} [options]
 
-Create an attestor in the current project.
+Create an attestor.
 
-Options:
-  -n <attestor name>   Name to use for attestor
-  -p <project ID>      Project ID
-  -i <image path>      Full image path including sha (gcr.io/my-project/image-name@sha256:....)
-  -b <bucket name>     Name of the GCS Bucket with KMS decryption keys
-  -r <keyring name>    Name of the KMS keyring decryption key
-  -k <key name>        Name of the KMS decryption key
-  -h                   This help screen"
+Global options:
+  -p <project>
+      ID of the Google Cloud project (e.g. \"my-project\")
+  -i <image>
+      Full image including SHA (e.g. \"gcr.io/my-project/my-image@sha245:...\")
+
+Attestor options:
+  -a <attestor>
+      ID of the attestor (e.g. \"my-attestor\")
+  -A <attestor project>
+      ID of the project where the attestor exists. Defaults to the global
+      project ID.
+
+KMS options:
+  -v <kms key version>
+      Version of the KMS key to use for signing (e.g. \"1\")
+  -k <kms key>
+      Name of the KMS get (e.g. \"my-key\")
+  -l <kms location>
+      Location of the KMS key (e.g. \"global\")
+  -r <kms key ring>
+      Name of the KMS keyring (e.g. \"my-keyring\")
+  -V <kms project>
+      ID of the project where the KMS key exists. Defaults to the global
+      project ID.
+"
 }
 
-while getopts 'hn:p:i:b:r:k:' flag; do
+while getopts 'p:i:a:A:v:k:l:r:V:h' flag; do
   case ${flag} in
-    h) usage ;;
     p) PROJECT_ID="${OPTARG}" ;;
     i) IMAGE_PATH="${OPTARG}" ;;
-    n) NAME="${OPTARG}" ;;
-    b) BUCKET_NAME="${OPTARG}" ;;
-    r) KEYRING="${OPTARG}" ;;
-    k) KEY="${OPTARG}" ;;        
+
+    a) ATTESTOR="${OPTARG}" ;;
+    A) ATTESTOR_PROJECT="${OPTARG}" ;;
+
+
+    v) KMS_KEY_VERSION="${OPTARG}" ;;
+    k) KMS_KEY="${OPTARG}" ;;
+    l) KMS_LOCATION="${OPTARG}" ;;
+    r) KMS_KEYRING="${OPTARG}" ;;
+    V) KMS_PROJECT="${OPTARG}" ;;
+
+    h) usage; exit 0 ;;
     *) die "invalid option found" ;;
   esac
 done
 
-if [ -z "$NAME" ]
+if [ -z "${PROJECT_ID:-}" ]; then
+  die '$PROJECT_ID or -p must be set'
+fi
+
+if [ -z "${IMAGE_PATH:-}" ]; then
+  die '$IMAGE_PATH or -i must be set'
+fi
+
+if [ -z "${ATTESTOR:-}" ]; then
+  die '$ATTESTOR or -a must be set'
+fi
+
+if [ -z "${KMS_KEY_VERSION:-}" ]; then
+  die '$KMS_KEY_VERSION or -v must be set'
+fi
+
+if [ -z "${KMS_KEY:-}" ]; then
+  die '$KMS_KEY or -k must be set'
+fi
+
+if [ -z "${KMS_LOCATION:-}" ]; then
+  die '$KMS_LOCATION or -l must be set'
+fi
+
+if [ -z "${KMS_KEYRING:-}" ]; then
+  die '$KMS_KEYRING or -r must be set'
+fi
+
+# Default parent properties
+ATTESTOR_PROJECT="${ATTESTOR_PROJECT:-${PROJECT_ID}}"
+KMS_PROJECT="${KMS_PROJECT:-${PROJECT_ID}}"
+
+# Verify that the image wasn't already attested.
+if gcloud beta container binauthz attestations list \
+      --artifact-url "${IMAGE_PATH}" \
+      --attestor "${ATTESTOR}" \
+      --attestor-project "${ATTESTOR_PROJECT}" \
+      --format json \
+      | jq '.[0].kind' \
+      | grep 'ATTESTATION'
 then
-   usage
-   die "Name must be set"
+  echo "Image has already been attested."
+  exit 0
 fi
 
-if [ -z "$IMAGE_PATH" ]
-then
-   usage
-   die "Image must be set"
-fi
-
-if [ -z "$PROJECT_ID" ]
-then
-   usage
-   die "Project must be set"
-fi
-
-if [ -z "$BUCKET_NAME" ]
-then
-   usage
-   die "BUCKET_NAME must be set"
-fi
-
-if [ -z "$KEYRING" ]
-then
-   usage
-   die "KEYRING must be set"
-fi
-
-if [ -z "$KEY" ]
-then
-   usage
-   die "KEY must be set"
-fi
-
-if gcloud beta container binauthz attestations list --artifact-url $IMAGE_PATH --attestor $NAME --format json | jq '.[0].kind' | grep ATTESTATION; then
-echo "Image has already been attested."
-exit 0
-fi
-
-# Get signing keys
-gsutil cp gs://${BUCKET_NAME}/${NAME}.fpr gs://${BUCKET_NAME}/${NAME}.gpg.enc gs://${BUCKET_NAME}/${NAME}.pass.enc .
-gcloud kms decrypt --ciphertext-file=${NAME}.gpg.enc \
-                --plaintext-file=${NAME}.gpg \
-                --location=global \
-                --keyring=${KEYRING} \
-                --key=${KEY}
-gcloud kms decrypt --ciphertext-file=${NAME}.pass.enc \
-                --plaintext-file=${NAME}.pass \
-                --location=global \
-                --keyring=${KEYRING} \
-                --key=${KEY}
-gcloud beta container binauthz create-signature-payload \
-    --artifact-url=${IMAGE_PATH} > generated_payload.json
-
-# Sign attestation
-mkdir -p ~/.gnupg
-echo allow-loopback-pinentry > ~/.gnupg/gpg-agent.conf
-COMMON_FLAGS="--no-tty --pinentry-mode loopback  --passphrase-file ${NAME}.pass"
-gpg2 $COMMON_FLAGS --import ${NAME}.gpg
-gpg2 $COMMON_FLAGS --output generated_signature.pgp --local-user $(cat ${NAME}.fpr) --armor --sign generated_payload.json
-
-# Upload attestation
-gcloud beta container binauthz attestations create \
-    --artifact-url="${IMAGE_PATH}" \
-    --attestor="projects/${PROJECT_ID}/attestors/${NAME}" \
-    --signature-file=generated_signature.pgp \
-    --public-key-id="$(cat ${NAME}.fpr)"
-
-# Clean up the keys and generated artifacts
-rm generated_signature.pgp generated_payload.json ${NAME}.fpr ${NAME}.pass ${NAME}.pass.enc ${NAME}.gpg ${NAME}.gpg.enc
+# Sign and create the attestation.
+gcloud alpha container binauthz attestations sign-and-create \
+  --project "${PROJECT_ID}" \
+  --artifact-url "${IMAGE_PATH}" \
+  --attestor "${ATTESTOR}" \
+  --attestor-project "${ATTESTOR_PROJECT}" \
+  --keyversion "${KMS_KEY_VERSION}" \
+  --keyversion-key "${KMS_KEY}" \
+  --keyversion-location "${KMS_LOCATION}" \
+  --keyversion-keyring "${KMS_KEYRING}" \
+  --keyversion-project "${KMS_PROJECT}"


### PR DESCRIPTION
This PR is accompanied with an internal solution CL. In short, this updates the helper scripts and solution to use Cloud KMS directly.

At present, the solution relies on gnupg to generate keys, Cloud KMS to encrypt those keys, and Cloud Storage to store those keys. Instead, we can cut 20% of the tutorial down by leveraging Cloud KMS asymmetric keys directly, obviating the need for gnupg and Cloud Storage as dependencies. This is also much better from a security perspective, since the private keys are never exposed.