### PR TITLE
Update gcloud commands to use latest CLIs

### DIFF
--- a/scripts/create_attestation.sh
+++ b/scripts/create_attestation.sh
@@ -108,7 +108,7 @@ ATTESTOR_PROJECT="${ATTESTOR_PROJECT:-${PROJECT_ID}}"
 KMS_PROJECT="${KMS_PROJECT:-${PROJECT_ID}}"
 
 # Verify that the image wasn't already attested.
-if gcloud beta container binauthz attestations list \
+if gcloud container binauthz attestations list \
       --artifact-url "${IMAGE_PATH}" \
       --attestor "${ATTESTOR}" \
       --attestor-project "${ATTESTOR_PROJECT}" \
@@ -121,7 +121,7 @@ then
 fi
 
 # Sign and create the attestation.
-gcloud alpha container binauthz attestations sign-and-create \
+gcloud beta container binauthz attestations sign-and-create \
   --project "${PROJECT_ID}" \
   --artifact-url "${IMAGE_PATH}" \
   --attestor "${ATTESTOR}" \


### PR DESCRIPTION
This PR is accompanied with an internal solution CL. In short, this updates the helper script and solution to align latest gcloud CLIs.

As Binary Authorization became GA, we should check the status and update the solution and commands at this timing. But it seems that some commands are not available in the GA track yet.